### PR TITLE
Support for array as argument to FenwickTree#new

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ For the convinience of usage in programming contest, each class in the library d
 ## [FenwickTree.cr](atcoder/FenwickTree.cr) ([<atcoder/fenwicktree>](https://atcoder.github.io/ac-library/document_en/fenwicktree.html))
 
 * `fenwick_tree<T> fw(n)` => `AtCoder::FenwickTree(T).new(n)`
+* `fenwick_tree<T> fw(array)` => `AtCoder::FenwickTree(T).new(array)`
 
   ```cr
   tree = AtCoder::FenwickTree(Int64).new(10)

--- a/atcoder/FenwickTree.cr
+++ b/atcoder/FenwickTree.cr
@@ -28,8 +28,19 @@ module AtCoder
     getter size : Int64
     getter bits : Array(T)
 
-    def initialize(@size)
+    def initialize(@size : Int64)
       @bits = Array(T).new(@size, T.zero)
+    end
+
+    def initialize(@bits : Array)
+      @bits = @bits.dup
+      @size = @bits.size.to_i64
+      (1 ... @size).each do |index|
+        up = index + (index & -index)
+        next if up > @size
+
+        @bits[up - 1] += @bits[index - 1]
+      end
     end
 
     # Implements atcoder::fenwick_tree.add(index, value)

--- a/spec/atcoder/FenwickTree_spec.cr
+++ b/spec/atcoder/FenwickTree_spec.cr
@@ -22,6 +22,18 @@ require "spec"
 alias FenwickTree = AtCoder::FenwickTree
 
 describe "FenwickTree" do
+  describe "#new(array)" do
+    it "equals #new(int64)" do
+      a = [10, 20, 30, 40, 50, 60, 70].map(&.to_i64)
+      tree1 = FenwickTree(Int64).new(a)
+      tree2 = FenwickTree(Int64).new(a.size.to_i64)
+      a.each_with_index{ |e, i| tree2.add(i, e) }
+
+      tree1.size.should eq tree2.size
+      tree1.bits.should eq tree2.bits
+    end
+  end
+
   describe "#left_sum" do
     it "calculates left_sum of given list" do
       tree = FenwickTree(Int64).new(11_i64)


### PR DESCRIPTION
- [x] Tests pass
- [x] Appropriate changes to README are included in PR

I've made it so that FenweickTree#new can take an array as an argument.

new(int): 292ms
https://atcoder.jp/contests/practice2/submissions/22893243

new(array): 268ms
https://atcoder.jp/contests/practice2/submissions/22895055 