### PR TITLE
Fix syntax highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ require "atcoder/fenwick_tree" # load FenwickTree
 
     Yields each item in the queue in comparator's order.
 
-    ヒープを破壊せず列挙するため、$O(n \log{n})$ の前計算を行っています。ただし、`#first` は $O(1)$ で動作するように最適化されています。 it pre-calculates in $O(n \log{n})$ to enumerate without destroying the heap. Note, however, that `#first` works for $O(1)$
+    ヒープを破壊せず列挙するため、O(NlogN) の前計算を行っています。ただし、`#first` は O(1) で動作するように最適化されています。 it pre-calculates in O(NlogN) to enumerate without destroying the heap. Note, however, that `#first` works for O(1).
 
     ```cr
     q = AtCoder::PriorityQueue.new(1..n)


### PR DESCRIPTION
- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR

## Overview

数式記法がMarkdownに含まれていると、コードブロックのシンタックスハイライトが壊れてしまったため、数式記法を削除しました。