### PR TITLE
Implement LCP Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ require "atcoder/fenwick_tree" # load FenwickTree
 ## [`atcoder/string`](https://google.github.io/ac-library.cr/docs/src/string.cr) (Implements [<atcoder/string>](https://atcoder.github.io/ac-library/document_en/string.html))
 
 * `suffix_array(s)` => `AtCoder::String.suffix_array(s)`
-* `lcp_array(s)` => Unimplemented
+* `lcp_array(s)` => `AtCoder::String.lcp_array(s)`
 * `z_algorithm(s)` => `AtCoder::String.z_algorithm(s)`
 
 ## [`atcoder/dsu`](https://google.github.io/ac-library.cr/docs/src/dsu.cr) (Implements [<atcoder/dsu>](https://atcoder.github.io/ac-library/document_en/dsu.html))

--- a/spec/string_spec.cr
+++ b/spec/string_spec.cr
@@ -41,6 +41,20 @@ describe "String" do
     end
   end
 
+  describe ".lcp_array" do
+    it "returns lcp_array" do
+      AtCoder::String.lcp_array("abcbcba", AtCoder::String.suffix_array("abcbcba")).should eq [1, 0, 1, 3, 0, 2]
+      AtCoder::String.lcp_array("mississippi", AtCoder::String.suffix_array("mississippi")).should eq [1, 1, 4, 0, 0, 1, 0, 2, 1, 3]
+      AtCoder::String.lcp_array("ababacaca", AtCoder::String.suffix_array("ababacaca")).should eq [1, 3, 1, 3, 0, 2, 0, 2]
+      AtCoder::String.lcp_array("aaaaa", AtCoder::String.suffix_array("aaaaa")).should eq [1, 2, 3, 4]
+
+      AtCoder::String.lcp_array([1, 2, 3, 2, 3, 2, 1], AtCoder::String.suffix_array([1, 2, 3, 2, 3, 2, 1])).should eq [1, 0, 1, 3, 0, 2]
+      AtCoder::String.lcp_array([12, 8, 18, 18, 8, 18, 18, 8, 15, 15, 8], AtCoder::String.suffix_array([12, 8, 18, 18, 8, 18, 18, 8, 15, 15, 8])).should eq [1, 1, 4, 0, 0, 1, 0, 2, 1, 3]
+      AtCoder::String.lcp_array([1, 2, 1, 2, 1, 3, 1, 3, 1], AtCoder::String.suffix_array([1, 2, 1, 2, 1, 3, 1, 3, 1])).should eq [1, 3, 1, 3, 0, 2, 0, 2]
+      AtCoder::String.lcp_array([1, 1, 1, 1, 1], AtCoder::String.suffix_array([1, 1, 1, 1, 1])).should eq [1, 2, 3, 4]
+    end
+  end
+
   describe ".z_algorithm" do
     it "returns empty array if input sequence is empty" do
       AtCoder::String.z_algorithm([] of Int32).should eq [] of Int32

--- a/src/string.cr
+++ b/src/string.cr
@@ -217,6 +217,28 @@ module AtCoder
       sa_is(sequence.bytes.map(&.to_i32), 255)
     end
 
+    # returns lcp array in O(n)
+    def self.lcp_array(sequence, sa)
+      n = sequence.size
+      rank = [0] * n
+      sa.each_with_index { |e, i| rank[e] = i }
+
+      lcp = [0] * (n - 1)
+      h = 0
+      n.times do |i|
+        h -= 1 if h > 0
+        next if rank[i] == 0
+        j = sa[rank[i] - 1]
+        while j + h < n && i + h < n
+          break if sequence[j + h] != sequence[i + h]
+          h += 1
+        end
+        lcp[rank[i] - 1] = h
+      end
+
+      lcp
+    end
+
     # returns z array
     def self.z_algorithm(sequence)
       n = sequence.size

--- a/verify/lcp_array.test.cr
+++ b/verify/lcp_array.test.cr
@@ -21,5 +21,5 @@ require "../src/string.cr"
 s = read_line
 n = s.size
 sa = AtCoder::String.suffix_array(s)
-ans = n.to_i64 * (n + 1) // 2 - AtCoder::String.lcp_array(s, sa).sum
+ans = n.to_i64 * (n + 1) // 2 - AtCoder::String.lcp_array(s, sa).sum(&.to_i64)
 puts ans

--- a/verify/lcp_array.test.cr
+++ b/verify/lcp_array.test.cr
@@ -1,0 +1,25 @@
+# ac-library.cr by hakatashi https://github.com/google/ac-library.cr
+#
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# verification-helper: PROBLEM https://judge.yosupo.jp/problem/number_of_substrings
+
+require "../src/string.cr"
+
+s = read_line
+n = s.size
+sa = AtCoder::String.suffix_array(s)
+ans = n.to_i64 * (n + 1) // 2 - AtCoder::String.lcp_array(s, sa).sum
+puts ans


### PR DESCRIPTION
- [x] Tests pass
- [x] Appropriate changes to README are included in PR

## Overview

I've implemented `String.lcp_array` (and reverted `spec/string_algorithm_spec.cr`  to `spec/string_spec.cr`). 

```crystal
s = "abcbcba"
sa = AtCoder::String.suffix_array(s)
AtCoder::String.lcp_array(s, sa) # => [1, 0, 1, 3, 0, 2]
```

## Original

https://github.com/atcoder/ac-library/blob/f669803f78c3acc72671ca6e41b4eeb0469364a8/atcoder/string.hpp#L209-L243

## Verified

https://judge.yosupo.jp/problem/number_of_substrings