### PR TITLE
Improve LazySegTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ require "atcoder/fenwick_tree" # load FenwickTree
   tree[50...80] #=> 0
   ```
 
-  * `.set(p, x)` => Unimplemented
+  * `.set(p, x)` => `#set(p, x)`
   * `.get(p)` => `#[](p)`
   * `.prod(l, r)` => `#[](l...r)`
   * `.all_prod()` => `#all_prod`

--- a/README.md
+++ b/README.md
@@ -108,8 +108,10 @@ require "atcoder/fenwick_tree" # load FenwickTree
   * `.all_prod()` => `#all_prod`
   * `.apply(p, f)` => `#[]=(p, f)`
   * `.apply(l, r, f)` => `#[]=(l...r, f)`
-  * `.max_right<f>(l)` => Unimplemented
-  * `.max_left<f>(r)` => Unimplemented
+  * `.max_right<f>(l)` => `#max_right(l, e = nil, &f)`
+    * 明示的に単位元を与えない場合、`f(e: nil) = true` として計算します。If the identity element is not given, it computes as `f(e: nil) = true`.
+  * `.min_left<f>(r)` => `#min_left(r, e = nil, &f)`
+    * 明示的に単位元を与えない場合、`f(e: nil) = true` として計算します。If the identity element is not given, it computes as `f(e: nil) = true`.
 
 ## [`atcoder/string`](https://google.github.io/ac-library.cr/docs/src/string.cr) (Implements [<atcoder/string>](https://atcoder.github.io/ac-library/document_en/string.html))
 

--- a/spec/lazy_seg_tree_spec.cr
+++ b/spec/lazy_seg_tree_spec.cr
@@ -54,6 +54,28 @@ describe "LazySegTree" do
     end
   end
 
+  describe "#set" do
+    it "sets value at index" do
+      op = ->(a : Int32, b : Int32) { a + b }
+      mapping = ->(f : Int32, x : Int32) { x * f }
+      composition = ->(a : Int32, b : Int32) { a * b }
+
+      segtree = LazySegTree(Int32, Int32).new([0] * 100, op, mapping, composition)
+      100.times { |i| segtree.set(i, i + 1) }
+
+      segtree[0...100].should eq 5050
+      segtree[10...50].should eq 1220
+      segtree[50...70].should eq 1210
+      segtree[12...33].should eq 483
+
+      segtree.set(0, 1000000)
+      segtree.set(10, 1000000)
+      segtree.set(100, 1000000)
+      segtree[0...100].should eq 5050 + 2 * 1000000 - (1 + 11)
+      segtree[0...101].should eq 5151 + 3 * 1000000 - (1 + 11 + 101)
+    end
+  end
+
   describe "#[]=" do
     it "updates value at selected index" do
       op = ->(a : Int32, b : Int32) { a + b }
@@ -94,6 +116,48 @@ describe "LazySegTree" do
       segtree[40].should eq 41
       segtree[41].should eq 42
       segtree[0...100].should eq 5050 + 410 + 240 + 355 * 4
+    end
+  end
+
+  describe "#max_right" do
+    it "applies a binary search on the segment tree" do
+      op = ->(a : Int32, b : Int32) { Math.min(a, b) }
+      mapping = ->(f : Int32, x : Int32) { x + f }
+      composition = ->(a : Int32, b : Int32) { a + b }
+      segtree = LazySegTree(Int32, Int32).new((-10..10).map(&.**(2)), op, mapping, composition)
+
+      (0..20).map { |i| segtree[0..i] }.to_a.should eq [100, 81, 64, 49, 36, 25, 16, 9, 4, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+      segtree.max_right(0) { |x| x >= 10**9 }.should eq 0
+      segtree.max_right(0) { |x| x >= 20 }.should eq 6
+      segtree.max_right(0) { |x| x >= 16 }.should eq 7
+      segtree.max_right(0) { |x| x >= -1 }.should eq 21
+
+      segtree.max_right(0) { |x| x <= 10**9 }.should eq 21
+
+      segtree.max_right(0, e: Int32::MAX) { |x| x >= 10**9 }.should eq 0
+      segtree.max_right(0, e: Int32::MAX) { |x| x <= 10**9 }.should eq nil
+    end
+  end
+
+  describe "#min_left" do
+    it "applies a binary search on the segment tree" do
+      op = ->(a : Int32, b : Int32) { Math.min(a, b) }
+      mapping = ->(f : Int32, x : Int32) { x + f }
+      composition = ->(a : Int32, b : Int32) { a + b }
+      segtree = LazySegTree(Int32, Int32).new((-10..10).map(&.**(2)), op, mapping, composition)
+
+      (0..20).map { |i| segtree[i..20] }.to_a.should eq [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 9, 16, 25, 36, 49, 64, 81, 100]
+
+      segtree.min_left(21) { |x| x >= 10**9 }.should eq 21
+      segtree.min_left(21) { |x| x >= 20 }.should eq 15
+      segtree.min_left(21) { |x| x >= 16 }.should eq 14
+      segtree.min_left(21) { |x| x >= -1 }.should eq 0
+
+      segtree.min_left(21) { |x| x <= 10**9 }.should eq 0
+
+      segtree.min_left(21, e: Int32::MAX) { |x| x <= 10**9 }.should eq nil
+      segtree.min_left(21, e: Int32::MAX) { |x| x >= 10**9 }.should eq 21
     end
   end
 

--- a/src/lazy_seg_tree.cr
+++ b/src/lazy_seg_tree.cr
@@ -39,7 +39,7 @@ module AtCoder
 
     def initialize(values : Array(S), @operator : S, S -> S, @application : F, S -> S, @composition : F, F -> F)
       @values = values.map { |v| v.as(S | Nil) }
-      segment_size = 2 ** ::Math.log2(@values.size).ceil.to_i - 1
+      segment_size = next_power_of_two_minus_one(@values.size)
       @segments = Array(S | Nil).new(segment_size, nil)
       @applicators = Array(F | Nil).new(segment_size, nil)
 
@@ -223,6 +223,15 @@ module AtCoder
     # FIXME: Unimplemented
     def max_left
       raise NotImplementedError.new
+    end
+
+    @[AlwaysInline]
+    private def next_power_of_two_minus_one(n : Int32)
+      n -= 1
+      {% for sh in [1, 2, 4, 8, 16] %}
+        n |= n >> {{ sh }}
+      {% end %}
+      n
     end
   end
 end

--- a/src/seg_tree.cr
+++ b/src/seg_tree.cr
@@ -34,7 +34,7 @@ module AtCoder
 
     def initialize(values : Array(T), &@operator : T, T -> T)
       @values = values
-      @segments = Array(T | Nil).new(next_power_of_two_minus_one(values.size), nil)
+      @segments = Array(T | Nil).new(2 ** log2_ceil(values.size) - 1, nil)
 
       # initialize segments
       (@segments.size - 1).downto(0) do |i|
@@ -158,12 +158,8 @@ module AtCoder
     end
 
     @[AlwaysInline]
-    private def next_power_of_two_minus_one(n : Int32)
-      n -= 1
-      {% for sh in [1, 2, 4, 8, 16] %}
-        n |= n >> {{ sh }}
-      {% end %}
-      n
+    private def log2_ceil(n : Int32) : Int32
+      sizeof(Int32)*8 - (n - 1).leading_zeros_count
     end
   end
 end

--- a/src/seg_tree.cr
+++ b/src/seg_tree.cr
@@ -34,7 +34,7 @@ module AtCoder
 
     def initialize(values : Array(T), &@operator : T, T -> T)
       @values = values
-      @segments = Array(T | Nil).new(2 ** ::Math.log2(values.size).ceil.to_i - 1, nil)
+      @segments = Array(T | Nil).new(next_power_of_two_minus_one(values.size), nil)
 
       # initialize segments
       (@segments.size - 1).downto(0) do |i|
@@ -155,6 +155,15 @@ module AtCoder
     # FIXME: Unimplemented
     def max_left
       raise NotImplementedError.new
+    end
+
+    @[AlwaysInline]
+    private def next_power_of_two_minus_one(n : Int32)
+      n -= 1
+      {% for sh in [1, 2, 4, 8, 16] %}
+        n |= n >> {{ sh }}
+      {% end %}
+      n
     end
   end
 end


### PR DESCRIPTION
- [x] Tests pass
- [x] Appropriate changes to README are included in PR

以下の変更を行いました。

 - `#set` / `#max_right` / `#min_left` の実装
 - パフォーマンスの向上のため、非再帰による実装に変更
   - (再帰 2895ms) : https://judge.yosupo.jp/submission/124670
   - (非再帰 2401ms) : https://judge.yosupo.jp/submission/125755

### 質問

非再帰の実装に変更する際、`@values` を削除してしまったのですが大丈夫でしょうか？
`@values.size` に相当する getter を設定しようかと思いましたが、適切な命名が思いつかず、一旦なしにしています。
  - `#size` だと `@segments` のサイズ  `2*(1 << log2_ceil(@values.size))` や `@applicators` のサイズ `1 << log2_ceil(@values.size)` と混同するかと思いましたが、実用上 `#size` にしてしまってもいい気はしています