### PR TITLE
Improve ModInt

### DIFF
--- a/src/mod_int.cr
+++ b/src/mod_int.cr
@@ -180,6 +180,14 @@ module AtCoder
           self
         end
 
+        def pred
+          self.class.new(@value - 1)
+        end
+
+        def succ
+          self.class.new(@value + 1)
+        end
+
         def zero?
           @value == 0
         end

--- a/src/mod_int.cr
+++ b/src/mod_int.cr
@@ -37,9 +37,12 @@ module AtCoder
 
         getter value : Int64
 
+        def initialize(@value : Int64)
+          @value %= MOD
+        end
+
         def initialize(value)
           @value = value.to_i64 % MOD
-          @value %= MOD unless 0 <= @value && @value < MOD
         end
 
         # Change the initial capacity of this array to improve performance
@@ -83,9 +86,7 @@ module AtCoder
         end
 
         def +(value)
-          val = value.to_i64
-          val %= MOD unless 0 <= val && val < MOD
-          self.class.new(@value + val)
+          self.class.new(@value + value.to_i64 % MOD)
         end
 
         def -(value : self)
@@ -93,9 +94,7 @@ module AtCoder
         end
 
         def -(value)
-          val = value.to_i64
-          val %= MOD unless 0 <= val && val < MOD
-          self.class.new(@value - val)
+          self.class.new(@value - value.to_i64 % MOD)
         end
 
         def *(value : self)
@@ -103,9 +102,7 @@ module AtCoder
         end
 
         def *(value)
-          val = value.to_i64
-          val %= MOD unless 0 <= val && val < MOD
-          self.class.new(@value * val)
+          self.class.new(@value * (value.to_i64 % MOD))
         end
 
         def /(value : self)

--- a/src/mod_int.cr
+++ b/src/mod_int.cr
@@ -39,6 +39,7 @@ module AtCoder
 
         def initialize(value)
           @value = value.to_i64 % MOD
+          @value %= MOD unless 0 <= @value && @value < MOD
         end
 
         # Change the initial capacity of this array to improve performance
@@ -77,16 +78,34 @@ module AtCoder
           self.class.new(x)
         end
 
+        def +(value : self)
+          self.class.new(@value + value.to_i64)
+        end
+
         def +(value)
-          self.class.new(@value + value.to_i64 % MOD)
+          val = value.to_i64
+          val %= MOD unless 0 <= val && val < MOD
+          self.class.new(@value + val)
+        end
+
+        def -(value : self)
+          self.class.new(@value - value.to_i64)
         end
 
         def -(value)
-          self.class.new(@value - value.to_i64 % MOD)
+          val = value.to_i64
+          val %= MOD unless 0 <= val && val < MOD
+          self.class.new(@value - val)
+        end
+
+        def *(value : self)
+          self.class.new(@value * value.to_i64)
         end
 
         def *(value)
-          self.class.new(@value * (value.to_i64 % MOD))
+          val = value.to_i64
+          val %= MOD unless 0 <= val && val < MOD
+          self.class.new(@value * val)
         end
 
         def /(value : self)
@@ -162,6 +181,10 @@ module AtCoder
 
         def abs
           self
+        end
+
+        def zero?
+          @value == 0
         end
 
         # ac-library compatibility


### PR DESCRIPTION
- [x] Tests pass
- [x] Appropriate changes to README are included in PR

## Optimization
`def initialize(@value : Int64)` が想像以上に効きました

`0 <= @value < MOD` のとき除算を避けるのは逆効果でした

### [Range Affine Range Sum](https://judge.yosupo.jp/problem/range_affine_range_sum)
 - (2201 ms): https://judge.yosupo.jp/submission/124693
 - (1615 ms): https://judge.yosupo.jp/submission/126125
### [Matrix Product](https://judge.yosupo.jp/problem/matrix_product)
 - (TLE): https://judge.yosupo.jp/submission/126138
 - (6812 ms): https://judge.yosupo.jp/submission/126137

## Add `#zero?`

`Int` に合わせて `@value == 0` を返すメソッドを追加

## Add `#succ` / `#pred`

`Int` に合わせて追加