### PR TITLE
Remove deprecated Array.each_product

### DIFF
--- a/src/prime.cr
+++ b/src/prime.cr
@@ -239,7 +239,7 @@ module AtCoder
       end
 
       def each(&)
-        Array.each_product(@exponential_factors) do |factors|
+        Indexable.each_cartesian(@exponential_factors) do |factors|
           yield factors.reduce { |a, b| a * b }
         end
       end


### PR DESCRIPTION
- [x] Tests pass (**excluding old 0.33**)
- [x] Appropriate changes to README are included in PR

### Overview

Use `Indexable.each_cartesian` in order to remove deprecated `Array.each_product`

```console
$ crystal spec
In src/prime.cr:242:15

 242 | Array.each_product(@exponential_factors) do |factors|
             ^-----------
Warning: Deprecated Array(T).each_product. Use `Indexable.each_cartesian(indexables : Indexable(Indexable), reuse = false, &block)` instead
```

