### PR TITLE
Add support for the `FenwickTree#sum` with open ended ranges

### DIFF
--- a/spec/fenwick_tree_spec.cr
+++ b/spec/fenwick_tree_spec.cr
@@ -68,11 +68,14 @@ describe "FenwickTree" do
       tree[0...3].should eq 3
       tree[3...7].should eq 18
       tree[0...11].should eq 55
-      tree[0...].should eq 55
-      tree[...11].should eq 55
-      tree[...].should eq 55
-      tree[..].should eq 55
       tree[7...7].should eq 0
+
+      tree[3...].should eq 52
+      tree[...6].should eq 15
+      tree[...].should eq 55
+      tree[3..].should eq 52
+      tree[..6].should eq 21
+      tree[..].should eq 55
     end
   end
 

--- a/spec/fenwick_tree_spec.cr
+++ b/spec/fenwick_tree_spec.cr
@@ -68,6 +68,10 @@ describe "FenwickTree" do
       tree[0...3].should eq 3
       tree[3...7].should eq 18
       tree[0...11].should eq 55
+      tree[0...].should eq 55
+      tree[...11].should eq 55
+      tree[...].should eq 55
+      tree[..].should eq 55
       tree[7...7].should eq 0
     end
   end

--- a/src/fenwick_tree.cr
+++ b/src/fenwick_tree.cr
@@ -67,11 +67,18 @@ module AtCoder
       left_sum(right) - left_sum(left)
     end
 
-    # :ditto:
-    def [](range : Range(Int, Int))
-      left = range.begin
-      right = range.exclusive? ? range.end : range.end + 1
+    # Implements atcoder::fenwick_tree.sum(left, right)
+    #
+    # Open ended ranges are clamped at the start and end of array, respectively.
+    def sum(range : Range)
+      left = range.begin || 0
+      right = range.exclusive? ? (range.end || @size) : (range.end || @size - 1) + 1
       sum(left, right)
+    end
+
+    # :ditto:
+    def [](range : Range)
+      sum(range)
     end
   end
 end


### PR DESCRIPTION
- [x] Tests pass
- [x] Appropriate changes to README are included in PR

## Overview

- 標準ライブラリに合わせて `Range` で open ended ranges に対応させました。
   - `tree[..3]`
   - `tree[1..]`
   - `tree[...]`