### PR TITLE
Add support for the `SegTree` and `LazySegTree` with open ended ranges

### DIFF
--- a/spec/lazy_seg_tree_spec.cr
+++ b/spec/lazy_seg_tree_spec.cr
@@ -51,6 +51,13 @@ describe "LazySegTree" do
       segtree[16..16].should eq 17
       segtree[49..49].should eq 50
       segtree[88..88].should eq 89
+
+      segtree[10...].should eq 4995
+      segtree[...60].should eq 1830
+      segtree[...].should eq 5050
+      segtree[10..].should eq 4995
+      segtree[..60].should eq 1891
+      segtree[..].should eq 5050
     end
   end
 

--- a/spec/lazy_seg_tree_spec.cr
+++ b/spec/lazy_seg_tree_spec.cr
@@ -123,6 +123,30 @@ describe "LazySegTree" do
       segtree[40].should eq 41
       segtree[41].should eq 42
       segtree[0...100].should eq 5050 + 410 + 240 + 355 * 4
+
+      segtree[1...] = 2
+      segtree[...5] = 2
+      segtree[...] = 2
+      segtree[0].should eq 1 * 2**2
+      segtree[1].should eq 2 * 2**3
+      segtree[2].should eq 3 * 2**3
+      segtree[3].should eq 4 * 2**3
+      segtree[4].should eq 5 * 2**3
+      segtree[5].should eq 6 * 2**2
+      segtree[6].should eq 7 * 2**2
+      segtree[99].should eq 100 * 2**2
+
+      segtree[1..] = 2
+      segtree[..5] = 2
+      segtree[..] = 2
+      segtree[0].should eq 1 * 2**4
+      segtree[1].should eq 2 * 2**6
+      segtree[2].should eq 3 * 2**6
+      segtree[3].should eq 4 * 2**6
+      segtree[4].should eq 5 * 2**6
+      segtree[5].should eq 6 * 2**5
+      segtree[6].should eq 7 * 2**4
+      segtree[99].should eq 100 * 2**4
     end
   end
 

--- a/spec/seg_tree_spec.cr
+++ b/spec/seg_tree_spec.cr
@@ -44,6 +44,13 @@ describe "SegTree" do
         segtree[16..16].should eq 17
         segtree[49..49].should eq 50
         segtree[88..88].should eq 89
+
+        segtree[10...].should eq 100
+        segtree[...60].should eq 60
+        segtree[...].should eq 100
+        segtree[10..].should eq 100
+        segtree[..60].should eq 61
+        segtree[..].should eq 100
       end
     end
 

--- a/src/lazy_seg_tree.cr
+++ b/src/lazy_seg_tree.cr
@@ -71,9 +71,10 @@ module AtCoder
     end
 
     # Implements atcoder::lazy_segtree.apply(left, right, applicator).
-    def []=(range : Range(Int, Int), applicator : F)
-      l = range.begin + @n_leaves
-      r = (range.exclusive? ? range.end : range.end + 1) + @n_leaves
+    # ameba:disable Metrics/CyclomaticComplexity
+    def []=(range : Range, applicator : F)
+      l = (range.begin || 0) + @n_leaves
+      r = (range.exclusive? ? (range.end || @n_leaves) : (range.end || @n_leaves - 1) + 1) + @n_leaves
 
       @height.downto(1) do |i|
         propagate(ancestor(l, i)) if right_side_child?(l, i)
@@ -110,9 +111,9 @@ module AtCoder
     end
 
     # Implements atcoder::lazy_segtree.prod(left, right).
-    def [](range : Range(Int, Int))
-      l = range.begin + @n_leaves
-      r = (range.exclusive? ? range.end : range.end + 1) + @n_leaves
+    def [](range : Range)
+      l = (range.begin || 0) + @n_leaves
+      r = (range.exclusive? ? (range.end || @n_leaves) : (range.end || @n_leaves - 1) + 1) + @n_leaves
 
       @height.downto(1) do |i|
         propagate(ancestor(l, i)) if right_side_child?(l, i)

--- a/src/seg_tree.cr
+++ b/src/seg_tree.cr
@@ -72,9 +72,9 @@ module AtCoder
     end
 
     # Implements atcoder::segtree.prod(l, r)
-    def [](range : Range(Int, Int))
-      l = range.begin + @n_leaves
-      r = (range.exclusive? ? range.end : range.end + 1) + @n_leaves
+    def [](range : Range)
+      l = (range.begin || 0) + @n_leaves
+      r = (range.exclusive? ? (range.end || @n_leaves) : (range.end || @n_leaves - 1) + 1) + @n_leaves
 
       sml, smr = nil.as(T | Nil), nil.as(T | Nil)
       while l < r


### PR DESCRIPTION
- [x] Tests pass
- [x] Appropriate changes to README are included in PR

## Overview
- 標準ライブラリに合わせて `Range` で open ended ranges に対応させました。
   - `tree[..3]`
   - `tree[1..]`
   - `tree[...]`